### PR TITLE
Blogs and community tile

### DIFF
--- a/_index.yml
+++ b/_index.yml
@@ -28,11 +28,11 @@ indexpage:
           url: /support-registration.html
         - title: Get help
           url: /get-help.html
-#    - title: Blogs & community
-#      links:
-#        - title: NetApp Community
-#          url: https://community.netapp.com/t5/Cloud-Data-Services/ct-p/CDS
-#        - title: Cloud Central blog
-#          url: https://cloud.netapp.com/blog
-#        - title: Cloud webinars
-#          url: https://cloud.netapp.com/events
+    - title: Blogs & community
+      links:
+        - title: NetApp Community 
+          url: https://community.netapp.com/t5/BlueXP-and-Services/ct-p/CDS
+        - title: BlueXP blogs 
+          url: https://bluexp.netapp.com/blog
+        - title: Cloud webinars 
+          url: https://bluexp.netapp.com/events   


### PR DESCRIPTION
Added a blogs and community tile to the landing page to provide relevant BlueXP reference pages to our users.