### PR TITLE
October release note date fix

### DIFF
--- a/whats-new.adoc
+++ b/whats-new.adoc
@@ -39,7 +39,7 @@ include::_whatsnew/2025-11-27.adoc[]
 
 include::_whatsnew/2025-11-02.adoc[]
 
-== 06 October 2026
+== 06 October 2025
 
 include::_whatsnew/2025-10-06.adoc[]
 


### PR DESCRIPTION
Changed the section heading from "06 October 2026" to "06 October 2025" in `whats-new.adoc` to fix an incorrect future date.