### PR TITLE
Tracker include

### DIFF
--- a/monitor-databases.adoc
+++ b/monitor-databases.adoc
@@ -4,37 +4,10 @@ permalink: monitor-databases.html
 keywords: monitor databases, monitor jobs, track database jobs
 summary: "Track database jobs and monitor databases within NetApp Workload Factory for Databases."  
 ---
-= Monitor database jobs in Workload Factory for Databases
+= Monitor operations in Workload Factory for Databases
 :icons: font
 :imagesdir: ./media/
 
 [.lead]
-Track database jobs and monitor databases within NetApp Workload Factory for Databases for improved visibility and control over database operations.
-
-== About this task 
-Databases provides job monitoring so you can track job progress, and diagnose and troubleshoot in case any failure occurs. You can filter jobs by type and status, find jobs using the search function, and download the jobs table.
-
-Job monitoring supports up to three levels of monitoring depending on the job. For example, for new database and sandbox clone creation, job monitoring tracks parent jobs and sub-jobs.  
-
-.Job monitoring levels
-
-* Level 1 (parent job): Tracks the host deployment job.
-* Level 2 (sub-job): Tracks the sub-jobs related to the host deployment parent job. 
-* Level 3 (task): Lists the sequence of actions taken on each resource.
-
-.Job status
-The job monitoring feature tracks _in progress_, _completed_, _completed with issues_, and _failed_ jobs daily, weekly, bi-weekly, and monthly.
-
-.Job events retention
-Job monitoring events are retained in the user interface for 30 days. 
-
-== Monitor jobs
-Monitor jobs to track the progress of database operations, and diagnose and troubleshoot in case any failure occurs.
-
-.Steps
-. Log in using one of the link:https://docs.netapp.com/us-en/workload-setup-admin/console-experiences.html[console experiences^].
-. Select the menu image:workloads-menu-icon.png[The hamburger menu icon is used to navigate to workloads like storage, eda, ai, databases, vmware, and administration.] and then select *Databases*.
-. From the Databases menu, select *Job monitoring*. 
-. In Job monitoring, use the filters or search to narrow job results. You can also download a jobs report. 
-. Optionally, select the action menu of the job and click *Go to CloudFormation* to view the job log in the AWS CloudFormation console.
+include::https://raw.githubusercontent.com/NetAppDocs/workload-setup-admin/main/_include/monitor-operations.adoc[]
 


### PR DESCRIPTION
This pull request updates the documentation for monitoring databases in NetApp Workload Factory for Databases. The main change is a significant simplification and standardization of the monitoring instructions by replacing detailed, page-specific content with a shared include file.

**Documentation simplification and standardization:**

* Replaced the entire detailed section on monitoring database jobs (including explanations of job monitoring levels, job status, events retention, and step-by-step instructions) in `monitor-databases.adoc` with an `include` directive that pulls standardized content from a shared location.